### PR TITLE
Support Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ void main() async {
   final recordName = 'Tasks';
 
   var airtable = Airtable(apiKey: apiKey, projectBase: projectBase);
-  var records = await airtable.getAllRecords(recordName);
+  // default pageSize is 100
+  var response = await airtable.getAllRecords(recordName); 
+  var records = response.records;
+  var offset = response.offset; // next page offset
 
   print(records);
 }

--- a/lib/src/airtable_record.dart
+++ b/lib/src/airtable_record.dart
@@ -9,6 +9,13 @@ extension FirstWhereOrNull<T> on Iterable<T> {
   }
 }
 
+class AirtableRecordsResponse {
+  List<AirtableRecord> records = [];
+  String? offset;
+
+  AirtableRecordsResponse(this.records, this.offset);
+}
+
 class AirtableRecord {
   final String? id;
   final DateTime? createdTime;


### PR DESCRIPTION
Support Pagination with `pageSize`, `maxRecords` and next `offset`.
The `getAllRecords()` method's result includes `offset` now.

From the document:

> Pagination
> The server returns one page of records at a time. Each page will contain `pageSize` records, which is 100 by default.
> If there are more records, the response will contain an `offset`. To fetch the next page of records, include `offset` in the next request's parameters.
> Pagination will stop when you've reached the end of your table. If the `maxRecords` parameter is passed, pagination will stop once you've reached this maximum. 
> Iteration may timeout due to client inactivity or server restarts. In that case, the client will receive a 422 response with error message `LIST_RECORDS_ITERATOR_NOT_AVAILABLE`. It may then restart iteration from the beginning
